### PR TITLE
fix ios textview bugs

### DIFF
--- a/ios/Classes/NativeTextInput.m
+++ b/ios/Classes/NativeTextInput.m
@@ -99,7 +99,7 @@
 
 - (void)onMethodCall:(FlutterMethodCall*)call result:(FlutterResult)result {
     if ([[call method] isEqualToString:@"getContentHeight"]) {
-        CGSize boundSize = CGSizeMake(_containerWidth, MAXFLOAT);
+        CGSize boundSize = CGSizeMake(_textView.frame.size.width, MAXFLOAT);
         CGSize size = [_textView sizeThatFits: boundSize];
         result([NSNumber numberWithFloat: size.height]);
     } else if ([[call method] isEqualToString:@"getLineHeight"]) {

--- a/lib/flutter_native_text_input.dart
+++ b/lib/flutter_native_text_input.dart
@@ -620,16 +620,26 @@ class _NativeTextInputState extends State<NativeTextInput> {
   }
 
   void _inputValueChanged(String? text, int? lineIndex) async {
-    if (text != null) {
-      _effectiveController.text = text;
-      if (widget.onChanged != null) widget.onChanged!(text);
+    if (text == null) {
+      return;
+    }
+    switch (defaultTargetPlatform) {
+      case TargetPlatform.android:
+        _effectiveController.text = text;
+        break;
+      case TargetPlatform.iOS:
+        break;
+      default:
+        break;
+    }
+    if (widget.onChanged != null) widget.onChanged!(text);
 
-      final channel = await _channel.future;
-      final value = await channel.invokeMethod("getContentHeight");
-      if (mounted && value != null && value != _contentHeight) {
+    final channel = await _channel.future;
+    final value = await channel.invokeMethod("getContentHeight");
+    if (mounted && value != null && value != _contentHeight) {
+      setState(() {
         _contentHeight = value;
-        setState(() {});
-      }
+      });
     }
   }
 


### PR DESCRIPTION
The following bugs have been fixed.
1) Textfield adds a new line before the current line is filled. As if there were an extra right-padding.
2) If user taps in the middle of the text, the cursor shifts to the end if user taps a key from the keyboard.
3) If user pastes some text from clipboard, a big bottom-padding is added to the textfield itself.
